### PR TITLE
Change record store

### DIFF
--- a/packages/traw/package.json
+++ b/packages/traw/package.json
@@ -73,6 +73,7 @@
     "@radix-ui/react-tooltip": "^1.0.2",
     "@tldraw/tldraw": "^1.26.3",
     "classnames": "^2.3.2",
+    "immer": "^9.0.16",
     "lodash": "^4.17.21",
     "nanoid": "^3.3.4",
     "uuid": "^9.0.0",

--- a/packages/traw/src/components/Slide/SlideList.tsx
+++ b/packages/traw/src/components/Slide/SlideList.tsx
@@ -1,3 +1,4 @@
+import { useTldrawApp } from 'hooks/useTldrawApp';
 import React, { useEffect, useRef } from 'react';
 import { useTrawApp } from '../../hooks/useTrawApp';
 import SvgAdd from '../../icons/add';
@@ -12,7 +13,8 @@ export interface SlideListProps {
 const SlideList = ({ canAddSlide, handleAddSlide, handleGridView }: SlideListProps) => {
   const slideRef = useRef<Record<string, HTMLElement>>({});
   const app = useTrawApp();
-  const state = app.useSlidesStore();
+  const tldrawApp = useTldrawApp();
+  const state = tldrawApp.useStore();
   const { document, appState } = state;
   const { currentPageId } = appState;
   const pages = document.pages;

--- a/packages/traw/src/components/Slide/SlideThumbnail.tsx
+++ b/packages/traw/src/components/Slide/SlideThumbnail.tsx
@@ -1,5 +1,6 @@
 import { Renderer } from '@tldraw/core';
 import { shapeUtils, TDPage } from '@tldraw/tldraw';
+import { useTldrawApp } from 'hooks/useTldrawApp';
 import React, { useMemo } from 'react';
 import { convertCameraTRtoTD } from 'state';
 import { useTrawApp } from '../../hooks/useTrawApp';
@@ -12,8 +13,10 @@ const SLideThumbnail = ({ page }: SlideThumbnailProps) => {
   const slideDomRef = React.useRef<HTMLDivElement>(null);
 
   const app = useTrawApp();
-  const state = app.useSlidesStore();
-  const camera = app.getCamera(page.id);
+  const tldrawApp = useTldrawApp();
+  const state = tldrawApp.useStore();
+  const camera = app.useStore((state) => state.camera[state.user.id][page.id]);
+  console.log('camera', camera);
   const tlCamera = useMemo(() => {
     return convertCameraTRtoTD(camera, { width: 133, height: 75 });
   }, [camera]);

--- a/packages/traw/src/components/Slide/SlideThumbnail.tsx
+++ b/packages/traw/src/components/Slide/SlideThumbnail.tsx
@@ -16,7 +16,6 @@ const SLideThumbnail = ({ page }: SlideThumbnailProps) => {
   const tldrawApp = useTldrawApp();
   const state = tldrawApp.useStore();
   const camera = app.useStore((state) => state.camera[state.user.id][page.id]);
-  console.log('camera', camera);
   const tlCamera = useMemo(() => {
     return convertCameraTRtoTD(camera, { width: 133, height: 75 });
   }, [camera]);

--- a/packages/traw/src/hooks/useTldrawApp.ts
+++ b/packages/traw/src/hooks/useTldrawApp.ts
@@ -1,0 +1,21 @@
+import { TldrawApp } from '@tldraw/tldraw';
+import { useEffect, useState } from 'react';
+import { TrawBaseEvent, TrawEventType } from 'state';
+import { useTrawApp } from './useTrawApp';
+
+export const useTldrawApp = () => {
+  const trawApp = useTrawApp();
+  const [tldrawApp, setTldrawApp] = useState<TldrawApp>(trawApp.app);
+
+  useEffect(() => {
+    const onChange = (event: TrawBaseEvent) => {
+      setTldrawApp(event.tldrawApp);
+    };
+    trawApp.on(TrawEventType.TldrawAppChange, onChange);
+    return () => {
+      trawApp.off(TrawEventType.TldrawAppChange, onChange);
+    };
+  }, [trawApp]);
+
+  return tldrawApp;
+};

--- a/packages/traw/src/state/TrawApp.ts
+++ b/packages/traw/src/state/TrawApp.ts
@@ -139,6 +139,7 @@ export class TrawApp {
   registerApp(app: TldrawApp) {
     app.callbacks = {
       onCommand: this.recordCommand,
+      onAssetCreate: this.handleAssetCreate,
       onPatch: (app, patch, reason) => {
         if (reason === 'sync_camera') return;
         const pageStates = patch.document?.pageStates;

--- a/packages/traw/src/state/events.ts
+++ b/packages/traw/src/state/events.ts
@@ -17,9 +17,7 @@ export interface CreateRecordsEvent extends TrawBaseEvent {
 export type CreateRecordsHandler = (event: CreateRecordsEvent) => void;
 
 /**
- * Event for newly created records
- *
- * Records added by TrawApp.addRecords will not trigger this event
+ * Event triggered when TldrawApp is changed. 
  */
 export type TldrawAppChangeEvent = TrawBaseEvent;
 

--- a/packages/traw/src/state/events.ts
+++ b/packages/traw/src/state/events.ts
@@ -17,7 +17,7 @@ export interface CreateRecordsEvent extends TrawBaseEvent {
 export type CreateRecordsHandler = (event: CreateRecordsEvent) => void;
 
 /**
- * Event triggered when TldrawApp is changed. 
+ * Event triggered when TldrawApp is changed.
  */
 export type TldrawAppChangeEvent = TrawBaseEvent;
 

--- a/packages/traw/src/state/events.ts
+++ b/packages/traw/src/state/events.ts
@@ -1,4 +1,4 @@
-import { Record } from 'types';
+import { TRRecord } from 'types';
 import { TldrawApp } from '@tldraw/tldraw';
 
 export interface TrawBaseEvent {
@@ -11,16 +11,26 @@ export interface TrawBaseEvent {
  * Records added by TrawApp.addRecords will not trigger this event
  */
 export interface CreateRecordsEvent extends TrawBaseEvent {
-  records: Record[];
+  records: TRRecord[];
 }
 
 export type CreateRecordsHandler = (event: CreateRecordsEvent) => void;
+
+/**
+ * Event for newly created records
+ *
+ * Records added by TrawApp.addRecords will not trigger this event
+ */
+export type TldrawAppChangeEvent = TrawBaseEvent;
+
+export type TldrawAppChangeHandler = (event: TldrawAppChangeEvent) => void;
 
 /**
  * Traw Event Types
  */
 export enum TrawEventType {
   CreateRecords = 'createRecords',
+  TldrawAppChange = 'tldrawAppChange',
 }
 
 /**
@@ -28,9 +38,10 @@ export enum TrawEventType {
  */
 export interface EventTypeHandlerMap {
   [TrawEventType.CreateRecords]: CreateRecordsHandler;
+  [TrawEventType.TldrawAppChange]: TldrawAppChangeHandler;
 }
 
 /**
  * Union type of event handlers
  */
-export type TrawEventHandler = CreateRecordsHandler;
+export type TrawEventHandler = CreateRecordsHandler | TldrawAppChangeHandler;

--- a/packages/traw/src/types.ts
+++ b/packages/traw/src/types.ts
@@ -25,7 +25,7 @@ export type TrawToolInfo = {
   shortcut: (string | number)[];
 };
 
-export type Record = {
+export type TRRecord = {
   type: ActionType;
   data: any;
   id: string;
@@ -53,7 +53,7 @@ export type TRCamera = {
 
 export type TrawSnapshot = {
   viewport: TRViewport;
-  records: Record[];
+  records: Record<string, TRRecord>;
   camera: {
     [userId: string]: {
       [slideId: string]: TRCamera;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8055,6 +8055,11 @@ ignore@^5.1.1, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.1.tgz#c2b1f76cb999ede1502f3a226a9310fdfe88d46c"
   integrity sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==
 
+immer@^9.0.16:
+  version "9.0.16"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.16.tgz#8e7caab80118c2b54b37ad43e05758cdefad0198"
+  integrity sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ==
+
 import-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"
@@ -10034,11 +10039,6 @@ nanoid@^3.3.1, nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
-
-nanoid@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.0.tgz#6e144dee117609232c3f415c34b0e550e64999a5"
-  integrity sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
- traw app store 에 hook 추가
- traw app 내 tldraw app 변경 이벤트 추가
- useTldrawApp hook 추가
- 이미 반영한 record 를 다시 apply 하지 않도록 필터
- 조금 더 간단히 state 를 변경하기 위해 immer 적용

---
- Add a hook in traw app store
- Add TldrawAppChange event in traw app
- Add useTldrawApp hook
- Filter out already existing records not to be re-applied
- Adopt immer to update state easier.