### PR TITLE
Add an empty block threshold to filter out empty & short blocks

### DIFF
--- a/packages/traw/package.json
+++ b/packages/traw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traw/traw",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "module": "build/index.esm.js",

--- a/packages/traw/src/recorder/TrawRecorder.ts
+++ b/packages/traw/src/recorder/TrawRecorder.ts
@@ -130,8 +130,10 @@ export class TrawRecorder {
   };
 
   private _onSilence = () => {
-    this._trawVoiceBlockGenerator.createBlock();
-    this._trawVoiceRecorder.splitVoiceChunk();
+    const isCreated = this._trawVoiceBlockGenerator.createBlock();
+    if (isCreated) {
+      this._trawVoiceRecorder.splitVoiceChunk();
+    }
   };
 
   private _onRecognized = (action: 'add' | 'update', result: SpeechRecognitionResult) => {


### PR DESCRIPTION
Add an empty block threshold to filter out empty & short blocks. 

Default value is 3300ms.

If the block is shorter than the given threshold and text recognition doesn't catch any text, a block will be discarded even if it's detected as talking.