### PR TITLE
Change implementation of readonly 

### DIFF
--- a/packages/traw/package.json
+++ b/packages/traw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traw/traw",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "module": "build/index.esm.js",

--- a/packages/traw/src/components/Doc/DocImageViewer.tsx
+++ b/packages/traw/src/components/Doc/DocImageViewer.tsx
@@ -30,7 +30,7 @@ const DocImageViewer = ({ time, userId }: DocImageViewerProps) => {
   return (
     <div className="aspect-video flex relative">
       <TrawContext.Provider value={trawApp}>
-        <Editor />
+        <Editor readOnly />
       </TrawContext.Provider>
     </div>
   );

--- a/packages/traw/src/components/Editor/Editor.tsx
+++ b/packages/traw/src/components/Editor/Editor.tsx
@@ -537,9 +537,11 @@ export const Editor = ({ components, functions, readOnly }: EditorProps) => {
             showPages={false}
             components={components}
             functions={functions}
-            readOnly={readOnly}
           />
         </AnimationFactory>
+        {readOnly && (
+          <div className="absolute left-0 right-0 top-0 bottom-0 bg-transparent w-full h-full z-50 bg-grey-100" />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
- Tldraw.readonly blocks to resetDocuments. It causes video player not to work correctly.